### PR TITLE
Add version unavailability message

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -43,6 +43,7 @@ var (
 		"release-documents-checked",
 		"required-tests-missing",
 		"evidence-missing",
+		"unable-to-process",
 	}
 	managedPRLabelTemplatesWithVersion = []string{
 		"release-%v",

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -824,6 +824,20 @@ func (s *PRSuite) GetLabelsAndCommentsFromSuiteResultsBuffer() (comment string, 
 	if err != nil {
 		return "", []string{}, "", err
 	}
+	releaseVersion, err := semver.NewSemver(s.KubernetesReleaseVersion)
+	if err != nil {
+		return "", []string{}, "", err
+	}
+	releaseVersionLatest, err := semver.NewSemver(s.KubernetesReleaseVersionLatest)
+	if err != nil {
+		return "", []string{}, "", err
+	}
+	if releaseVersion.GreaterThanOrEqual(releaseVersionLatest) {
+		_, err = common.ReadFile(path.Join(s.MetadataFolder, s.KubernetesReleaseVersionLatest, "conformance.yaml"))
+		if err != nil {
+			return fmt.Sprintf("The release version %v is unable to be processed at this time; Please wait as this version may become available soon.", s.KubernetesReleaseVersion), append(labels, "conformance-product-submission", "unable-to-process"), "pending", nil
+		}
+	}
 	uniquelyNamedStepsRun := []string{}
 	resultPrepares := []ResultPrepare{}
 	for _, c := range cukeFeatures {

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -833,7 +833,7 @@ func (s *PRSuite) GetLabelsAndCommentsFromSuiteResultsBuffer() (comment string, 
 		return "", []string{}, "", err
 	}
 	if releaseVersion.GreaterThanOrEqual(releaseVersionLatest) {
-		_, err = common.ReadFile(path.Join(s.MetadataFolder, s.KubernetesReleaseVersionLatest, "conformance.yaml"))
+		_, err = common.ReadFile(path.Join(s.MetadataFolder, s.KubernetesReleaseVersion, "conformance.yaml"))
 		if err != nil {
 			return fmt.Sprintf("The release version %v is unable to be processed at this time; Please wait as this version may become available soon.", s.KubernetesReleaseVersion), append(labels, "conformance-product-submission", "unable-to-process"), "pending", nil
 		}


### PR DESCRIPTION
Replaces regular message if the version of the PR is greater than or equal to the latest version and the latest conformance.yaml doesn't exist.

Fixes: #15 