### PR TITLE
Restore deprecated scenario

### DIFF
--- a/kodata/features/verify-conformance-release.feature
+++ b/kodata/features/verify-conformance-release.feature
@@ -126,6 +126,15 @@ Feature: verify conformance product submission PR
     Then the tests pass and are successful
     And all required tests are present
 
+# DEPRECATED
+  Scenario: the tests in junit_01.xml and e2e.log match
+    it appears that there is a mismatch of tests in junit_01.xml and e2e.log
+
+    Given an "e2e.log" file
+    And a "junit_01.xml" file
+    Then the tests match
+    And all required tests are present
+
   Scenario: there is only one commit
     it appears that there is not exactly one commit. Please rebase and squash with `git rebase -i HEAD` (https://git-scm.com/docs/git-rebase)
 


### PR DESCRIPTION
this scenario was removed in #41, due to the step _the tests match_ requiring the tests to be listed and present in the e2e.log, a thing which is present in <1.25 submissions.

I'm restoring it to ensure that <v1.25 submissions are still being checked correctly, but this should ultimately be removed for the next release