### PR TITLE
chore: remove failing cosign from cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,12 +12,5 @@ steps:
         ko build --base-import-paths --tags $_GIT_TAG .
   # TODO sign image with OIDC
   #      https://docs.sigstore.dev/signing/overview/#on-google-cloud-platform
-  - name: ghcr.io/sigstore/cosign/cosign:v2.0.1
-    env:
-      - GOOGLE_SERVICE_ACCOUNT_NAME=gcb-922@k8s-infra-ii-sandbox.iam.gserviceaccount.com
-    args:
-      - sign
-      - --recursive
-      - gcr.io/$PROJECT_ID/verify-conformance/verify-conformance-release:$_GIT_TAG
 substitutions:
   _GIT_TAG: '12345'


### PR DESCRIPTION
currently fails to see service account and pick up OIDC