### PR TITLE
chore: update setup-go to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         name: collect job run info
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache-dependency-path: go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
           echo "ko-docker-repo=${KO_DOCKER_REPO,,}" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache-dependency-path: go.sum

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -10,7 +10,7 @@ jobs:
         name: collect job run info
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache-dependency-path: go.sum

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -10,7 +10,7 @@ jobs:
         name: collect job run info
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache-dependency-path: go.sum

--- a/.github/workflows/reusable-gofmt.yml
+++ b/.github/workflows/reusable-gofmt.yml
@@ -10,7 +10,7 @@ jobs:
         name: collect job run info
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache-dependency-path: go.sum

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         name: collect job run info
         run: |
           echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: ${{ steps.run-info.outputs.go-version }}
           cache: false

--- a/.github/workflows/reusable-update-go-version.yml
+++ b/.github/workflows/reusable-update-go-version.yml
@@ -32,7 +32,7 @@ jobs:
           gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           gh auth status
       - id: setup-go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version: stable
       - id: run-info


### PR DESCRIPTION
A number of workflows are failing to process the setup-go (v4.1) action 
```
Run actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
Setup go version spec 
Warning: go-version input was not specified. The action will try to use pre-installed version.
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
Error: Command failed: go env GOPATH
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```
This PR updates all workflows to use the latest version [5.0.1](https://github.com/actions/setup-go/releases/tag/v5.0.1) 