### PR TITLE
chore: update setupgo in reusable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache-dependency-path: go.sum
       - id: build-binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
         run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
           echo "ko-docker-repo=${KO_DOCKER_REPO,,}" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache-dependency-path: go.sum
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
       - name: Configure AWS Credentials

--- a/.github/workflows/reusable-go-test.yml
+++ b/.github/workflows/reusable-go-test.yml
@@ -6,13 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache-dependency-path: go.sum
       - name: test
         id: test

--- a/.github/workflows/reusable-go-vet.yml
+++ b/.github/workflows/reusable-go-vet.yml
@@ -6,13 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache-dependency-path: go.sum
       - name: vet
         id: vet

--- a/.github/workflows/reusable-gofmt.yml
+++ b/.github/workflows/reusable-gofmt.yml
@@ -6,13 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache-dependency-path: go.sum
       - name: gofmt
         id: gofmt

--- a/.github/workflows/reusable-golangci-lint.yml
+++ b/.github/workflows/reusable-golangci-lint.yml
@@ -14,13 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - id: run-info
-        name: collect job run info
-        run: |
-          echo "go-version=$(go list -f {{.GoVersion}} -m)" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: ${{ steps.run-info.outputs.go-version }}
+          go-version-file: go.mod
+          check-latest: true
           cache: false
       - name: write .golangci.yml
         if: ${{ inputs.config }}


### PR DESCRIPTION
use go-version-file.

To attempt to resolve

```
Setup go version spec 
Warning: go-version input was not specified. The action will try to use pre-installed version.
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
Error: Command failed: go env GOPATH
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```

as seen in https://github.com/cncf-infra/verify-conformance/actions/runs/9054799737/job/24875066034?pr=149#step:4:1