### PR TITLE
ci(code-quality-check): declare contents: read

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   gobuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the code quality workflow. All 10 jobs (`gobuild`, `gofmt`, `goimports`, `golangci-lint`, `golint`, `gotest`, `govet`, `govulncheck`, `spellcheck`) run `./hack/verify-*.sh` scripts and don't call the GitHub API for writes.

YAML validated locally.